### PR TITLE
feat: make highlighted code sideways scrollable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Support for continuous integration with GitHub Actions. Backend and frontend will now build with every push to the `main` branch or to the opened PR. (@MarkoSagadin)
 - Automated release process with GitHub Actions. A new release can now be manually triggered by providing the next version tag under the _Actions_ tab in the GitHub Web UI. (@MarkoSagadin)
 - Added information on how to build the backend project for developers.
+- Added new "scrollable code blocks" options to the config file. When set to True, 
+the highlighted code blocks in generated Anki cards will be sideways scrollable. This 
+option is by default disabled, to ensure that it's addition doesn't break existing 
+users. (@MarkoSagadin)
 
 ### Fixed
 - When reviewing card styles in Anki from its editor view, night mode now triggers the night-mode styles as expected. (@MarkoSagadin)

--- a/frontend/src/style/modules/highlight/README.md
+++ b/frontend/src/style/modules/highlight/README.md
@@ -1,7 +1,7 @@
 # Highlight component
 ## Description
 This component is used to display highlighted code (read only). 
-It supports line numbering, line highlighting on hover and text-wrapping.
+It supports line numbering, line highlighting on hover and switchable scrollable code blocks.
 The resulting component is a block-level element.
 
 ## Classes
@@ -9,7 +9,9 @@ The resulting component is a block-level element.
     - highlight--linenos: an optional state that defines whether or not to have numbered lines
 - highlight__language: a label to display the language of the highlighted code
 - highlight__code: the container of the highlighted code
+    - highlight__code--scrollable-code: an optional state that defines whether or not to make the code scrollable horizontally.
 - highlight__line: the container of each line 
+    - highlight__line--no-wrap: See above.
     - :hover: highlight the line (change background)
     - ::before: line numbers
 

--- a/frontend/src/style/modules/highlight/highlight.sass
+++ b/frontend/src/style/modules/highlight/highlight.sass
@@ -30,6 +30,10 @@
             background: var(--codeline-hover-background)
             opacity: 1
 
+        &--scrollable-code
+            white-space: pre
+            overflow-wrap: normal
+
 .highlight__line:empty:after // Fixes empty lines
     content: " "
 
@@ -47,7 +51,9 @@
     border: 1px solid var(--accent-color)
     border-left: 5px solid var(--accent-color)
     padding: 5px
-    
+
+    &--scrollable-code
+      overflow-x: scroll
 
 .highlight + br // This br is added to allow users to write outside of the generated highlight container on anki  
     display: none

--- a/src/markdown2anki/__init__.py
+++ b/src/markdown2anki/__init__.py
@@ -53,6 +53,7 @@ def main():
             markdown_handle.content,
             config["Obsidian valut name"],
             linenos=config["line numbers?"],
+            scrollable_code=config["scrollable code blocks?"],
             interactive=True,
             fast_forward=config["fast forward?"],
             images_dir=config["search images folder"],

--- a/src/markdown2anki/config/config_setup/__init__.py
+++ b/src/markdown2anki/config/config_setup/__init__.py
@@ -124,6 +124,13 @@ def setup_typeConfig(base_path: Types.PathString, type_hints=False) -> TypeConfi
     )
     fileConfig.add_option(
         type="bool",
+        option="scrollable code blocks?",
+        help="Whether or not to make code blocks horizontally scrollable.",
+        important_help="Choices: True/False. Defaults to False.",
+        default="False",
+    )
+    fileConfig.add_option(
+        type="bool",
         option="fast forward?",
         help="Whether or not to continue processing cards when there is an error in them.\nWhen fast forwarding, cards with errors are skipped but can still be found in the bad cards file and be fixed.\nWhen not fast forwarding, you will be showed the card and asked if you want to continue or not.",
         important_help="Choices: True/False. Defaults to True.",

--- a/src/markdown2anki/md_2_anki/__init__.py
+++ b/src/markdown2anki/md_2_anki/__init__.py
@@ -29,6 +29,7 @@ def markdown_to_anki(markdown: Types.MDString, vault, **options):
 
     # Unpacking kwargs
     linenos = options.get("linenos", True)
+    scrollable_code = options.get("scrollable_code", False)
     interactive = options.get("interactive", False)
     fast_forward = options.get("fast_forward", False)
     images_dir = options.get("images_dir", None)
@@ -54,7 +55,8 @@ def markdown_to_anki(markdown: Types.MDString, vault, **options):
                 clozes_handler = HandleClozes(card)
 
                 formatted_card_with_hashes = process_card(
-                    clozes_handler.hashed_markdown, vault, linenos=linenos
+                    clozes_handler.hashed_markdown, vault, linenos=linenos,
+                    scrollable_code=scrollable_code
                 )
 
                 formatted_card = clozes_handler.inject_clozes(
@@ -62,7 +64,8 @@ def markdown_to_anki(markdown: Types.MDString, vault, **options):
                 )
                 processed_cards_with_cloze.append(formatted_card)
             else:
-                formatted_card = process_card(card, vault, linenos=linenos)
+                formatted_card = process_card(card, vault, linenos=linenos,
+                                              scrollable_code=scrollable_code)
                 processed_cards.append(formatted_card)
 
             if images_dir:

--- a/src/markdown2anki/md_2_anki/process_card/__init__.py
+++ b/src/markdown2anki/md_2_anki/process_card/__init__.py
@@ -35,9 +35,16 @@ def process_card(
     """
 
     linenos_in_highlight = options.get("linenos", True)
+    scrollable_code = options.get("scrollable_code", False)
 
     tabs = extract_tabs(markdown)
-    compiled_tabs = tabs_to_html(tabs, vault, linenos=linenos_in_highlight)
+    compiled_tabs = tabs_to_html(
+        tabs,
+        vault,
+        linenos=linenos_in_highlight,
+        scrollable_code=scrollable_code,
+    )
+
     formatted_tabs = format_tabs(compiled_tabs)
     swapped_card = get_swapped_card(formatted_tabs)
 

--- a/tests/integration/config/test_handle_configs.py
+++ b/tests/integration/config/test_handle_configs.py
@@ -214,6 +214,7 @@ class TestHandleConfigs:
         expected_config = {
             "Obsidian valut name": "Obsidian vault",
             "line numbers?": False,
+            "scrollable code blocks?": False,
             "search images folder": str(
                 Path(tests.__file__).parent / "assets" / "images"
             ),

--- a/tests/unit_tests/config/test_setup_typeConfig.py
+++ b/tests/unit_tests/config/test_setup_typeConfig.py
@@ -26,6 +26,7 @@ class TestTypeConfig:
             "Number of backups",
             "clear file?",
             "line numbers?",
+            "scrollable code blocks?",
             "fast forward?",
             "folders to exclude",
         ]


### PR DESCRIPTION
Hello after a long break! :)

This PR addresses one of my pain points with the code snippets on the smaller screens.

Previously, if the length of the code line would be too long, the code would be wrapped, making it harder to read.
Now, the whole code block becomes scrollable, enabling to see the rest of the code in a clear manner.

I have no "proper" knowledge of CSS. The change was made with a bit of trial and error. If there is a better way I would be happy to change it. 