### PR TITLE
infra: update versions of GitHub Actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,29 +14,29 @@ on:
 
 jobs:
   build-backend:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout last PR commit
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Checkout last tag
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.checkout_ref }}
 
       - name: Checkout main
         if: github.event_name == 'push'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: main
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.10"
           cache: "pip"
@@ -52,13 +52,13 @@ jobs:
 
       - name: Package artefacts
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/*
 
   build-frontend:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         node-version: ["14.x", "16.x", "18.x"]
@@ -66,24 +66,24 @@ jobs:
     steps:
       - name: Checkout last PR commit
         if: github.event_name == 'pull_request'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Checkout last tag
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.checkout_ref }}
 
       - name: Checkout main
         if: github.event_name == 'push'
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: main
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -13,10 +13,10 @@ env:
 
 jobs:
   update-changelog:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # Fetch history for all branches and tags
           fetch-depth: 0
@@ -36,7 +36,7 @@ jobs:
           fi
 
       - name: Update Changelog
-        uses: thomaseizinger/keep-a-changelog-new-release@ec0871fec381db64ab389886ffe8e6fc2b661e2c
+        uses: thomaseizinger/keep-a-changelog-new-release@v3.1.0
         with:
           tag: ${{ inputs.version }}
 
@@ -67,11 +67,11 @@ jobs:
     # Only run cleanup if either call-build or call-publish-release fail.
     needs: [call-build, call-publish-release]
     if: ${{ always() && contains(join(needs.*.result, ','), 'failure') }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ inputs.version }}
           # Fetch two commits, so you can hard reset below

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   publish-new-release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     environment:
       name: pypi
       url: https://pypi.org/project/markdown2anki/
@@ -22,25 +22,25 @@ jobs:
     steps:
       - name: Preprocess version tag
         run: |
-          # This is needed due to the mindsers/changelog-reader-action expecting 
+          # This is needed due to the mindsers/changelog-reader-action expecting
           # version tag without 'v' prefix.
           version_cut=$(echo "${{ inputs.release_version }}" | cut -c 2-)
           echo "release_version=${{ inputs.release_version }}" >> $GITHUB_ENV
           echo "release_version_cut=$version_cut" >> $GITHUB_ENV
 
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ env.release_version }}
 
       - name: Get latest Changelog entry
         id: changelog-reader
-        uses: mindsers/changelog-reader-action@v2.2.2
+        uses: mindsers/changelog-reader-action@v2.2.3
         with:
           version: ${{ env.release_version_cut }}
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist
@@ -49,7 +49,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Publish Release
-        uses: softprops/action-gh-release@v0.1.15
+        uses: softprops/action-gh-release@v2.2.1
         with:
           files: dist/*
           tag_name: ${{ env.release_version }}


### PR DESCRIPTION
The changes in this commit were prompted by the deprecation warning for the actions/upload-artifact@v3, which is used by the build.yaml for the Python code. One of the PRs failed to pass the CI because of this warning.

Once I started looking through the workflow files I realized that almost all actions required the version update.